### PR TITLE
get header length when it contains 2 bytes chars

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,8 @@ class TableFormatter implements DocumentFormattingEditProvider {
             // TODO: Fix the extra phantom cell in MarkDownDOM.
             header.pop();
             for (let index = 0; index < header.length; index++) {
-                lengths[index] = Math.max(lengths[index] || 0, header[index].trim().length);
+                let twoBytes = header[index].match(/[^\x01-\x7E]/g) || []
+                lengths[index] = Math.max(lengths[index] || 0, header[index].trim().length + twoBytes.length);
             }
 
             for (const row of body) {
@@ -84,7 +85,7 @@ class TableFormatter implements DocumentFormattingEditProvider {
             // Insert the header.
             markdown += '|';
             for (let index = 0; index < lengths.length; index++) {
-                markdown += ` ${(header[index] || '').trim().padEnd(lengths[index])} |`;
+                markdown += ` ${(header[index] || '').trim()} |`;
             }
 
             // TODO: Read correct line breaks from MarkDownDOM.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,7 +76,8 @@ class TableFormatter implements DocumentFormattingEditProvider {
                 // TODO: Fix the extra phantom cell in MarkDownDOM.
                 row.pop();
                 for (let index = 0; index < row.length; index++) {
-                    lengths[index] = Math.max(lengths[index] || 0, row[index].trim().length);
+                    let twoBytes = row[index].match(/[^\x01-\x7E]/g) || []
+                    lengths[index] = Math.max(lengths[index] || 0, row[index].trim().length + twoBytes.length);
                 }
             }
 
@@ -85,7 +86,8 @@ class TableFormatter implements DocumentFormattingEditProvider {
             // Insert the header.
             markdown += '|';
             for (let index = 0; index < lengths.length; index++) {
-                markdown += ` ${(header[index] || '').trim()} |`;
+                let twoBytes = header[index].match(/[^\x01-\x7E]/g) || []
+                markdown += ` ${(header[index] || '').trim().padEnd(lengths[index] - twoBytes.length)} |`;
             }
 
             // TODO: Read correct line breaks from MarkDownDOM.
@@ -104,7 +106,9 @@ class TableFormatter implements DocumentFormattingEditProvider {
             for (const row of body) {
                 markdown += '|';
                 for (let index = 0; index < lengths.length; index++) {
-                    markdown += ` ${(row[index] || '').trim().padEnd(lengths[index])} |`;
+                    let line = row[index] || ''
+                    let twoBytes = line.match(/[^\x01-\x7E]/g) || [];
+                    markdown += ` ${(line).trim().padEnd(lengths[index] - twoBytes.length)} |`;
                 }
 
                 // TODO: Read correct line breaks from MarkDownDOM.


### PR DESCRIPTION
Hi!

Thanks for making a useful tool. 
I'm using your extension a lot.

but, I have some troubles when I use it with some 2 bytes chars such as Chinese chars or Japanese Hiragana.
So, I added a feature which gets a proper header length when it contains 2 bytes chars.

Originally, it was like
![original](https://user-images.githubusercontent.com/23311128/51816312-55a40080-2309-11e9-9f4e-573604094b9f.gif)

and I changed it like
![changed](https://user-images.githubusercontent.com/23311128/51816320-5d63a500-2309-11e9-9669-eca9ba500827.gif)
